### PR TITLE
Updates to support homebridge-gsh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@homebridge/hap-client` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## v2.0.4 (2024-11-07)
+
+### Changed
+
+- Added public method destroy, to be used for testing
+- Update public method monitorCharacteristics to allow passing of a filtered services array.
+
 ## v2.0.2 (2024-08-31)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 </span>
 
-A client for an insecure HAP-NodeJS instance.
+A client for an insecure HAP-NodeJS instance. Provides a Typescript based interface based on the homekit accessory protocol, allowing the creation of clients able to connect to and control Homebridge devices.
 
 # Dependant Applications
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A client for an insecure HAP-NodeJS instance.
 - homebridge-config-ui-x
 - homebridge-gsh
 
-(NPM Dependants)[https://www.npmjs.com/package/@homebridge/hap-client?activeTab=dependents]
+- [NPM Dependants](https://www.npmjs.com/package/@homebridge/hap-client?activeTab=dependents)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
 
 A client for an insecure HAP-NodeJS instance.
 
+# Dependant Applications
+
+- homebridge-config-ui-x
+- homebridge-gsh
+
+(NPM Dependants)[https://www.npmjs.com/package/@homebridge/hap-client?activeTab=dependents]
+
 ## Credits
 
 - HAP Client was originally created by [oznu](https://github.com/oznu).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@homebridge/hap-client",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@homebridge/hap-client",
-      "version": "2.0.2",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "axios": "1.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@homebridge/hap-client",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "description": "A client for HAP-NodeJS.",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,9 @@ export class HapClient extends EventEmitter {
     Characteristics.Name,
   ];
 
-  private resetInstancePoolTimeout: NodeJS.Timeout | undefined = undefined
-  private startDiscoveryTimeout: NodeJS.Timeout | undefined = undefined
+  private resetInstancePoolTimeout: NodeJS.Timeout | undefined = undefined;
+  private startDiscoveryTimeout: NodeJS.Timeout | undefined = undefined;
+  private hapMonitor: HapMonitor;
 
   constructor(opts: {
     pin: string;
@@ -60,6 +61,9 @@ export class HapClient extends EventEmitter {
     }
   }
 
+  /**
+   * resetInstancePool - Reset the instance pool, useful for when a Homebridge instance is restarted
+   */
   public resetInstancePool() {
     if (this.discoveryInProgress) {
       this.browser.stop();
@@ -74,6 +78,9 @@ export class HapClient extends EventEmitter {
     }, 6000);
   }
 
+  /**
+   * refreshInstances - Refresh the instance pool
+   */
   public refreshInstances() {
     if (!this.discoveryInProgress) {
       this.startDiscovery();
@@ -228,12 +235,24 @@ export class HapClient extends EventEmitter {
     return accessories;
   }
 
+  /**
+   * monitorCharacteristics
+   * @param services - Optional array of services to monitor
+   * 
+   * Creates connections to all Homebridge instances and monitors all characteristics for changes.  Will emit `service-update` events when characteristics change, which can be listened to.
+   * @returns 
+   */
   public async monitorCharacteristics(services?: ServiceType[]) {
     // If `services` is not provided, retrieve all services
     services = services ?? await this.getAllServices();
-    return new HapMonitor(this.logger, this.debug.bind(this), this.pin, services);
+    this.hapMonitor = new HapMonitor(this.logger, this.debug.bind(this), this.pin, services);
+    return this.hapMonitor;
   }
 
+  /**
+   * 
+   * @returns Array of all services from all Homebridge instances
+   */
   public async getAllServices() {
     /* Get Accessories from HAP */
     const accessories = await this.getAccessories();
@@ -452,11 +471,12 @@ export class HapClient extends EventEmitter {
   }
 
   /**
- * Destroy the HapClient instance, used for testing
- */
-  public destroy() {
-    this.browser?.stop()
-    this.discoveryInProgress = false
+   * Destroy the HAP client, used by testing when shutting down
+   */
+  public async destroy() {
+    this.browser?.stop();
+    this.hapMonitor?.finish();
+    this.discoveryInProgress = false;
     if (this.resetInstancePoolTimeout) {
       clearTimeout(this.resetInstancePoolTimeout)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,9 @@ export class HapClient extends EventEmitter {
     Characteristics.Name,
   ];
 
+  private resetInstancePoolTimeout: NodeJS.Timeout | undefined = undefined
+  private startDiscoveryTimeout: NodeJS.Timeout | undefined = undefined
+
   constructor(opts: {
     pin: string;
     logger?: any;
@@ -66,7 +69,7 @@ export class HapClient extends EventEmitter {
 
     this.instances = [];
 
-    setTimeout(() => {
+    this.resetInstancePoolTimeout = setTimeout(() => {
       this.refreshInstances();
     }, 6000);
   }
@@ -94,7 +97,7 @@ export class HapClient extends EventEmitter {
     this.debug(`[HapClient] Discovery :: Started`);
 
     // stop discovery after 20 seconds
-    setTimeout(() => {
+    this.startDiscoveryTimeout = setTimeout(() => {
       this.browser.stop();
       this.debug(`[HapClient] Discovery :: Ended`);
       this.discoveryInProgress = false;
@@ -225,8 +228,9 @@ export class HapClient extends EventEmitter {
     return accessories;
   }
 
-  public async monitorCharacteristics() {
-    const services = await this.getAllServices();
+  public async monitorCharacteristics(services?: ServiceType[]) {
+    // If `services` is not provided, retrieve all services
+    services = services ?? await this.getAllServices();
     return new HapMonitor(this.logger, this.debug.bind(this), this.pin, services);
   }
 
@@ -445,6 +449,20 @@ export class HapClient extends EventEmitter {
 
   private humanizeString(string: string) {
     return titleize(decamelize(string));
+  }
+
+  /**
+ * Destroy the HapClient instance, used for testing
+ */
+  public destroy() {
+    this.browser?.stop()
+    this.discoveryInProgress = false
+    if (this.resetInstancePoolTimeout) {
+      clearTimeout(this.resetInstancePoolTimeout)
+    }
+    if (this.startDiscoveryTimeout) {
+      clearTimeout(this.startDiscoveryTimeout)
+    }
   }
 
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -75,12 +75,7 @@ export interface ServiceType {
   setCharacteristic?: (iid: number, value: number | string | boolean) => Promise<ServiceType>;
   getCharacteristic?: (type: string) => CharacteristicType;
   values: any;
-  instance: {
-    ipAddress: string;
-    port: number;
-    username: string;
-    name: string;
-  };
+  instance: HapInstance;
   uniqueId?: string;
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,12 +20,7 @@ export interface HapEvInstance {
 
 export interface HapAccessoriesRespType {
   accessories: Array<{
-    instance: {
-      ipAddress: string;
-      port: number;
-      username: string;
-      name: string;
-    };
+    instance: HapInstance;
     aid: number;
     services: Array<{
       iid: number;

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -3,6 +3,9 @@ import { EventEmitter } from 'node:events';
 import { ServiceType, HapEvInstance } from './interfaces';
 import { createConnection, parseMessage } from './eventedHttpClient';
 
+/**
+ * HapMonitor - Creates a monitor to watch for changes in accessory characteristics.  And generates 'service-update' events when they change.
+ */
 export class HapMonitor extends EventEmitter {
   private pin;
   private evInstances: HapEvInstance[];


### PR DESCRIPTION
- Added public method destroy, to be used for testing
- Update public method monitorCharacteristics to allow passing of a filtered services array.